### PR TITLE
Don't use destructive operation on a frozen string

### DIFF
--- a/lib/lcoveralls/color_formatter.rb
+++ b/lib/lcoveralls/color_formatter.rb
@@ -43,7 +43,7 @@ module Lcoveralls
     # @param progname [String] Name of the program that generated the message.
     # @param msg [String] The message to format.
     def call(severity, datetime, progname, msg)
-      severity.capitalize!
+      severity = severity.capitalize
       if severity == 'Warn' then severity = 'Warning' end
 
       if %w[Warning Error Fatal Unknown].include?(severity) then


### PR DESCRIPTION
It seems that a string passed to `Lcoveralls::call' in
color_formatter.rb is frozen in ruby implementation(ruby-2.4). The
implementation is installed to travis-ci.

As the result, `capitalize!', a destructive operation on the string
causes errors like:

    Finished .info-file creation

    /home/.../lcoveralls/color_formatter.rb:46:in `capitalize!': can't
    modify frozen String (RuntimeError)

This change replaces `capitalize!' with `capitalize' to avoid the
error.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>