### PR TITLE
Fix wrong usage of '%' in format ()

### DIFF
--- a/lib/lcoveralls/runner.rb
+++ b/lib/lcoveralls/runner.rb
@@ -94,7 +94,7 @@ module Lcoveralls
       perc = lines_hit.to_f / lines_found.to_f * 100.0
       color = case when perc >= 90; 32 when perc >= 75; 33 else 31 end
       if bold then color = "1;#{color}" end
-      perc = perc.finite? ? format('%5.1f%', perc) : ' ' * 6
+      perc = perc.finite? ? format('%5.1f%%', perc) : ' ' * 6
       perc = "\x1b[#{color}m#{perc}\x1b[0m" if @options[:color] and color
       perc
     end


### PR DESCRIPTION
It seems that the usage of '%' char in format() is more strict in a new
ruby implementation available in travis these days.
As the result, the converge summarization is failed with following message:
```
Traceback (most recent call last):
	12: from /home/travis/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
	11: from /home/travis/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
	10: from /home/travis/.rvm/gems/ruby-2.5.3/bin/lcoveralls:23:in `<main>'
	 9: from /home/travis/.rvm/gems/ruby-2.5.3/bin/lcoveralls:23:in `load'
	 8: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/bin/lcoveralls:23:in `<top (required)>'
	 7: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:265:in `run'
	 6: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:116:in `get_source_files'
	 5: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:116:in `each'
	 4: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:122:in `block in get_source_files'
	 3: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:122:in `each'
	 2: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:158:in `block (2 levels) in get_source_files'
	 1: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:97:in `get_percentage'
/home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:97:in `format': incomplete format specifier; use %% (double %) instead (ArgumentError)
```

This change replaces '%' with '%%' to fix the wrong usage.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>